### PR TITLE
Update FSS-Storage-Stack.template

### DIFF
--- a/aws/FSS-Storage-Stack.template
+++ b/aws/FSS-Storage-Stack.template
@@ -820,6 +820,7 @@ Resources:
                   - s3:GetObject
                   - s3:GetObjectTagging
                   - s3:PutObjectTagging
+                  - s3:ListBucket
                 Resource: !Sub arn:${AWS::Partition}:s3:::${S3BucketToScan}/*
   PostScanActionTagPolicyForDLQ:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
Adding missing S3 permission for PostScan actions

Error Message: failed to get existing tags: An error occurred (AccessDenied) when calling the GetObjectTagging operation: User: arn:aws:sts:::assumed-role/All-in-one-TM-FileStorage-PostScanActionTagExecutio-XXXXXX/All-in-one-TM-FileStorageS-PostScanActionTagLambda-XXXXXX is not authorized to perform: s3:ListBucket on resource: "arn:aws:s3:::demo-fss-XXXX-demo" because no identity-based policy allows the s3:ListBucket action

